### PR TITLE
feat: do not fail the build when password is an unset env var

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("org.sonatype.plexus:plexus-sec-dispatcher:1.4")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.assertj:assertj-core:3.19.0")
+    testImplementation("com.github.stefanbirkner:system-rules:1.19.0")
 }
 
 java {

--- a/src/main/kotlin/com/bonitasoft/gradle/maven/settings/LocalMavenSettingsLoader.kt
+++ b/src/main/kotlin/com/bonitasoft/gradle/maven/settings/LocalMavenSettingsLoader.kt
@@ -1,16 +1,21 @@
 package com.bonitasoft.gradle.maven.settings
 
+import org.apache.maven.settings.Server
 import org.apache.maven.settings.Settings
-import org.apache.maven.settings.building.*
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest
+import org.apache.maven.settings.building.SettingsBuildingException
+import org.gradle.api.logging.Logger
 import org.sonatype.plexus.components.cipher.DefaultPlexusCipher
-import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher
+import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher.SYSTEM_PROPERTY_SEC_LOCATION
 import org.sonatype.plexus.components.sec.dispatcher.SecUtil
 import java.io.File
 
 
-class LocalMavenSettingsLoader(private val extension: MavenSettingsPluginExtension) {
-    val globalSettingsFile = File(System.getenv("M2_HOME"), "conf/settings.xml")
-    val settingsSecurityFileLocation = System.getProperty("user.home") + "/.m2/settings-security.xml"
+class LocalMavenSettingsLoader(private val extension: MavenSettingsPluginExtension, private val logger: Logger) {
+    private val globalSettingsFile = File(System.getenv("M2_HOME"), "conf/settings.xml")
+    private val settingsSecurityFile = File(System.getProperty("user.home") + "/.m2/settings-security.xml")
+    private val cipher = DefaultPlexusCipher()
 
 
     /**
@@ -20,55 +25,49 @@ class LocalMavenSettingsLoader(private val extension: MavenSettingsPluginExtensi
      * @return Effective settings
      * @throws SettingsBuildingException If the effective settings cannot be built
      */
-    fun loadSettings(): Settings {
-        val settingsBuildingRequest: SettingsBuildingRequest = DefaultSettingsBuildingRequest()
-        settingsBuildingRequest.userSettingsFile = extension.getUserSettingsFile()
-        settingsBuildingRequest.globalSettingsFile = globalSettingsFile
-        settingsBuildingRequest.systemProperties = System.getProperties()
+    fun loadSettings(): Settings =
+            DefaultSettingsBuilderFactory().newInstance().build(DefaultSettingsBuildingRequest().apply {
+                userSettingsFile = extension.getUserSettingsFile()
+                globalSettingsFile = this@LocalMavenSettingsLoader.globalSettingsFile
+                systemProperties = System.getProperties()
+            }).effectiveSettings.decryptCredentials()
 
-        val factory = DefaultSettingsBuilderFactory()
-        val settingsBuilder: DefaultSettingsBuilder = factory.newInstance()
-        val settingsBuildingResult: SettingsBuildingResult = settingsBuilder.build(settingsBuildingRequest)
-        val settings: Settings = settingsBuildingResult.effectiveSettings
-        decryptCredentials(settings)
-
-        return settings
-    }
-
-    fun decryptCredentials(settings: Settings): Unit {
+    private fun Settings.decryptCredentials(): Settings {
         try {
-            val masterPassword: String?
-            val cipher = DefaultPlexusCipher()
-            val settingsSecurityFile = File(settingsSecurityFileLocation)
-            var hasSettingsSecurity = false
-
-            if (settingsSecurityFile.exists() && !settingsSecurityFile.isDirectory) {
-                val settingsSecurity = SecUtil.read(settingsSecurityFileLocation, true)
-                masterPassword = cipher.decryptDecorated(settingsSecurity.master, DefaultSecDispatcher.SYSTEM_PROPERTY_SEC_LOCATION)
-                hasSettingsSecurity = true
-            }else{
-                masterPassword = null
+            val masterPassword = when {
+                settingsSecurityFile.exists() && !settingsSecurityFile.isDirectory ->
+                    cipher.decryptDecorated(SecUtil.read(settingsSecurityFile.absolutePath, true).master, SYSTEM_PROPERTY_SEC_LOCATION)
+                else -> null
             }
 
-            for (server in settings.servers) {
-                if (cipher.isEncryptedString(server.password)) {
-                    if (hasSettingsSecurity) {
-                        server.password = cipher.decryptDecorated(server.password, masterPassword!!)
-                    } else {
-                        throw RuntimeException ("Maven settings contains encrypted credentials yet no settings-security.xml exists.")
-                    }
+            servers.forEach { server ->
+                logger.debug("Processing credentials for server ${server.id}")
+                server.password?.apply {
+                    server.password = handlePasswordDecryption(server, this, masterPassword)
                 }
-
-                if (cipher.isEncryptedString(server.passphrase)) {
-                    if (hasSettingsSecurity) {
-                        server.passphrase = cipher.decryptDecorated(server.passphrase, masterPassword)
-                    } else {
-                        throw RuntimeException ("Maven settings contains encrypted credentials yet no settings-security.xml exists.")
-                    }
+                server.passphrase?.apply {
+                    server.passphrase = handlePasswordDecryption(server, this, masterPassword)
                 }
             }
         } catch (e: Exception) {
             throw RuntimeException("Unable to decrypt local Maven settings credentials.", e)
         }
+        return this
+    }
+
+    private fun handlePasswordDecryption(server: Server, password: String, masterPassword: String?): String {
+        if (password.startsWith("\${env.")) {
+            logger.warn("It looks like the password provided for the server ${server.id} uses an unknown env variable ${
+                password.substring("\${env.".length, password.length - 1)
+            }")
+        } else if (cipher.isEncryptedString(password)) {
+            if (masterPassword == null) {
+                throw RuntimeException("Maven settings contains encrypted credentials yet no settings-security.xml exists.")
+            }
+            val decryptDecorated = cipher.decryptDecorated(password, masterPassword)
+            logger.debug("Successfully decrypted password/passphrase for server ${server.id}")
+            return decryptDecorated
+        }
+        return password
     }
 }


### PR DESCRIPTION
When the password set on a server was an unknown env variable
`${env.SOME_VAR}`. If the env variable was unset, the plugin was trying
to decrypt it and made the build fails.

Avoid that by only printing a WARNING in logs
