### PR TITLE
fix: mirror overriding profile with same id

### DIFF
--- a/src/main/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPlugin.kt
+++ b/src/main/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPlugin.kt
@@ -135,7 +135,7 @@ class MavenSettingsPlugin : Plugin<Project> {
                 return@filter false
             }
             repo.getMirror(settings)?.also { mirror ->
-                project.logger.info("Replaced '${repo.name}' with mirror ${mirror.id} configured in maven's settings.xml")
+                project.logger.info("Replaced '${repo.name}' with mirror '${mirror.id}' configured in maven's settings.xml")
                 mirrorsToAdd.putIfAbsent(mirror.id) { repo ->
                     repo.name = mirror.id
                     repo.url = URI.create(mirror.url)

--- a/src/main/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPlugin.kt
+++ b/src/main/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPlugin.kt
@@ -28,7 +28,6 @@ import org.gradle.authentication.http.HttpHeaderAuthentication
 import java.net.InetAddress
 import java.net.NetworkInterface
 import java.net.URI
-import java.util.function.Predicate
 
 const val EXTENSION_NAME = "mavenSettings"
 
@@ -130,14 +129,14 @@ class MavenSettingsPlugin : Plugin<Project> {
     }
 
     private fun registerMirrors(project: Project) {
-        val mirrorsToAdd = mutableMapOf<String,Action<MavenArtifactRepository>>()
+        val mirrorsToAdd = mutableMapOf<String, Action<MavenArtifactRepository>>()
         project.repositories.toList().filter { repo ->
             if (repo.name.equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_LOCAL_REPO_NAME)) {
                 return@filter false
             }
             repo.getMirror(settings)?.also { mirror ->
                 project.logger.info("Replaced '${repo.name}' with mirror ${mirror.id} configured in maven's settings.xml")
-                mirrorsToAdd.putIfAbsent(mirror.id){ repo ->
+                mirrorsToAdd.putIfAbsent(mirror.id) { repo ->
                     repo.name = mirror.id
                     repo.url = URI.create(mirror.url)
                 }

--- a/src/main/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPlugin.kt
+++ b/src/main/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPlugin.kt
@@ -134,6 +134,7 @@ class MavenSettingsPlugin : Plugin<Project> {
             if (repo.name.equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_LOCAL_REPO_NAME)) {
                 return@filter false
             }
+            // If the current repository has a mirror defined in maven's settings.xml:
             repo.getMirror(settings)?.also { mirror ->
                 project.logger.info("Replaced '${repo.name}' with mirror '${mirror.id}' configured in maven's settings.xml")
                 mirrorsToAdd.putIfAbsent(mirror.id) { repo ->

--- a/src/test/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPluginTest.kt
+++ b/src/test/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPluginTest.kt
@@ -705,4 +705,35 @@ class MavenSettingsPluginTest {
             assertThat(it.name).isEqualTo("mirror")
         }
     }
+
+    @Test
+    fun `mirrors should override repositories when id is the same`() {
+        withSettings {
+            profile {
+                id = "profile1"
+                repository {
+                    id = "my.unique.repo"
+                    url = "http://maven.repo1.com"
+                }
+            }
+            mirror {
+                id = "my.unique.repo"
+                url = "http://maven.mirror.com"
+                mirrorOf = "*"
+            }
+            activeProfiles = listOf("profile1")
+        }
+        project.run {
+            repositories.apply {
+                mavenCentral()
+            }
+        }
+
+        applyPlugin()
+
+        //No profile 3, profile is not activated
+        assertThat(project.repositories).hasSize(1).first().satisfies {
+            assertThat(it.name).isEqualTo("my.unique.repo")
+        }
+    }
 }

--- a/src/test/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPluginTest.kt
+++ b/src/test/kotlin/com/bonitasoft/gradle/maven/settings/MavenSettingsPluginTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import java.io.File
+import java.net.URI
 import java.nio.file.Paths
 
 class MavenSettingsPluginTest {
@@ -731,9 +732,10 @@ class MavenSettingsPluginTest {
 
         applyPlugin()
 
-        //No profile 3, profile is not activated
+        // mirror should replace the one from profile (even with same id)
         assertThat(project.repositories).hasSize(1).first().satisfies {
             assertThat(it.name).isEqualTo("my.unique.repo")
+            assertThat((it as MavenArtifactRepository).url).isEqualTo(URI("http://maven.mirror.com"))
         }
     }
 }


### PR DESCRIPTION
When a mirror was declared with the same id than a repository added in a
profile, it was removing the one added from the profile without adding
the mirror itself.

Change the way to add mirror to avoid that issue (use a map to keep
trace of mirror to add)