### PR TITLE
refactor(build): no need to use external GH action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,5 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build
+    - name: Build with Gradle
+      run: ./gradlew build


### PR DESCRIPTION
as there is a gradle wrapper included
